### PR TITLE
add initial CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+* @andrewhsu
+/clients @jrkinley
+/docker-compose @jrkinley
+/docs @coral-waters
+/ebooks @kminguez
+/partners @jrkinley
+/spark @jrkinley
+/wasm @jrkinley @patrickangeles


### PR DESCRIPTION
New PRs are open to this repo and not sure who to ask for review.

This PR adds a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file so people are notified to review new PRs.

Initial owners based on git commit history of the directory.

I've put myself down as the catchall, but willing to add others or change it.